### PR TITLE
Add condition to trigger CI/CD only if repo owner - humanprotocol

### DIFF
--- a/.github/workflows/trigger_docker_build_and_deploy.yml
+++ b/.github/workflows/trigger_docker_build_and_deploy.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   trigger-build-and-deploy:
+    if: github.repository.owner == 'humanprotocol'
     name: Trigger build and deploy image
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
in order to prevent expected healthily failed deploys upon wrongly sources or wrongly targeted PRs adding checks to skip those