### PR TITLE
Add PR check and condition to trigger CI/CD only if repo owner - humanprotocol

### DIFF
--- a/.github/workflows/trigger_docker_build_and_deploy.yml
+++ b/.github/workflows/trigger_docker_build_and_deploy.yml
@@ -12,8 +12,27 @@ permissions:
   contents: read
 
 jobs:
+  pull-request-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: PR check
+        run: |
+          if [[ $GITHUB_REPOSITORY_OWNER == 'humanprotocol' ]] && [[ $GITHUB_BASE_REF == 'master' ]] && [[ $GITHUB_HEAD_REF == 'develop' ]]; then
+            echo "LGTM. PR from $GITHUB_HEAD_REF to $GITHUB_BASE_REF."
+          elif [[ $GITHUB_BASE_REF != 'master' ]]; then
+            echo "LGTM. PR from $GITHUB_HEAD_REF to $GITHUB_BASE_REF."
+          else
+            echo "Check out the target branch. A PR to 'master' can only be from the 'develop' branch within the 'humanprotocol' organization."
+            exit 1
+          fi
+
   trigger-build-and-deploy:
-    if: github.repository.owner == 'humanprotocol'
+    if: always() && github.repository_owner == 'humanprotocol' && (needs.pull-request-check.result == 'skipped' || needs.pull-request-check.result == 'success')
+    needs: pull-request-check
     name: Trigger build and deploy image
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
in order to prevent expected healthily failed deploys (which can confuse contributors as it was with escrow-factory PRs) upon wrongly sources or wrongly targeted PRs — adding checks:

It skips builds&deploys for non-humanprotocol external forks
And it fails with an informative error message "Check out the target branch. A PR to 'master' can only be from the 'develop' branch within the 'humanprotocol' organization." if the contributors try to target master (which reflects stable production)
